### PR TITLE
Custom color themes and list command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.dll
 *.so
 *.dylib
+gowall
 
 # Test binary, built with `go test -c`
 *.test

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -12,46 +12,41 @@ import (
 )
 
 var (
-	theme string
+	theme      string
 	batchFiles []string
 )
 
-
 var convertCmd = &cobra.Command{
 	Use:   "convert [image path / batch flag]",
-	Short: "convert an img's color shceme",
-	Long: `convert an img's color shceme`,
+	Short: "Convert an img's color scheme",
+	Long:  `Convert an img's color scheme`,
 	// Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-
 		switch {
 
 		case len(batchFiles) > 0:
 			fmt.Println("Processing batch files...")
 			processor := &image.ThemeConverter{}
 			expandedFiles := utils.ExpandHomeDirectory(batchFiles)
-			image.ProcessBatchImgs(expandedFiles,theme,processor)
+			image.ProcessBatchImgs(expandedFiles, theme, processor)
 
 		case len(args) > 0:
 			fmt.Println("Processing single image...")
 			processor := &image.ThemeConverter{}
 			expandFile := utils.ExpandHomeDirectory(args)
-			image.ProcessImg(expandFile[0], processor,theme)
-			
+			image.ProcessImg(expandFile[0], processor, theme)
+
 		default:
 			fmt.Println("Error: requires at least 1 arg(s), only received 0")
 			_ = cmd.Usage()
 		}
-
-
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(convertCmd)
-	convertCmd.Flags().StringVarP(&theme,"theme","t","catpuccin","Usage : --theme [ThemeName-Lowercase]")
-	convertCmd.Flags().StringSliceVarP(&batchFiles,"batch","b",nil,"Usage: --batch [file1.png,file2.png ...]")
+	convertCmd.Flags().StringVarP(&theme, "theme", "t", "catpuccin", "Usage : --theme [ThemeName-Lowercase]")
+	convertCmd.Flags().StringSliceVarP(&batchFiles, "batch", "b", nil, "Usage: --batch [file1.png,file2.png ...]")
 
 	// Here you will define your flags and configuration settings.
-
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,28 @@
+/*
+Copyright © 2024 Achnologia <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/Achno/gowall/internal/image"
+	"github.com/spf13/cobra"
+)
+
+// invertCmd represents the invert command
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Lists available themes",
+	Long:  `List all available themes. This includes the predefined and custom user provided themes`,
+	Run: func(cmd *cobra.Command, args []string) {
+		allThemes := image.ListThemes()
+		for _, theme := range allThemes {
+			fmt.Println(theme)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(listCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.5
 require (
 	github.com/chai2010/webp v1.1.1
 	github.com/spf13/cobra v1.8.1
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -8,5 +8,7 @@ github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/image/themes.go
+++ b/internal/image/themes.go
@@ -18,8 +18,8 @@ type Theme struct {
 }
 
 type themeWrapper struct {
-	Name   string   `yaml:"Name"`
-	Colors []string `yaml:"Colors"`
+	Name   string   `yaml:"name"`
+	Colors []string `yaml:"colors"`
 }
 
 // Available themes
@@ -72,6 +72,10 @@ func loadCustomThemes() {
 	}
 	for _, tw := range rawConfig.Themes {
 		valid := true
+		if tw.Name == "" || len(tw.Colors) == 0 {
+			// skip invalid color
+			continue
+		}
 		theme := Theme{
 			Name:   tw.Name,
 			Colors: make([]color.Color, len(tw.Colors)),

--- a/internal/image/themes.go
+++ b/internal/image/themes.go
@@ -42,7 +42,12 @@ func loadCustomThemes() {
 	// if you ever standardize config files change this
 	configDir, err := os.UserConfigDir()
 	if err != nil {
-		configDir = filepath.Join(os.Getenv("HOME"), ".config")
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			// cant find home or config just give up
+			return
+		}
+		configDir = filepath.Join(homeDir, ".config")
 	}
 	configPath := filepath.Join(configDir, "gowall", "config.yml")
 


### PR DESCRIPTION
Hello. I added the ability to add custom themes in a yaml file and added a command to list available themes. i wanted to use this program personally but i didn't want to have to open a pr and wait for merge any time i wanted to add an unsupported theme or change a color. 

I look for $XDG_CONFIG_HOME/gowall/config.yml or $HOME/.config/gowall/config.yml if you want to standardize your config file or use a flag to pass in the config file path eventually that will need to change. 

I made the parser just read hex strings and convert them to color.Color. you might want to consider doing that in your code so its easier to add themes to the codebase without converting them. 

let me know if you dont like any of this or want something changed

example config file

``` yaml
themes:
  - name: "theme1"
    colors:
      - "#F5E0DC"
      - "#F2CDCD"
      - "#F5C2E7"
      - "#CBA6F7"
      - "#F38BA8"
      - "#EBA0AC"
      - "#FAB387"
      - "#F9E2AF"
      - "#A6E3A1"
      - "#94E2D5"
      - "#89DCEB"
      - "#74C7EC"
      - "#89B4FA"
      - "#B4BEFE"
      - "#CDD6F4"
      - "#BAC2DE"
      - "#A6ADC8"
      - "#9399B2"
      - "#7F849C"
      - "#6C7086"
      - "#585B70"
      - "#45475A"
      - "#313244"
      - "#1E1E2E"
      - "#181825"
      - "#11111B"
  - name: "othertheme"
    colors:
      - "#F73253"
      - "#FA39DF"
      - "#005382"
      - "#123456"
```