### PR TITLE
Add FreeBSD platform support

### DIFF
--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -162,6 +162,8 @@ func OpenImage(filePath string) error {
 		cmd = exec.Command("open", filePath)
 	case "linux":
 		cmd = exec.Command("xdg-open", filePath)
+	case "freebsd":
+		cmd = exec.Command("xdg-open", filePath)
 
 	default:
 		return fmt.Errorf("unsupported platform")

--- a/utils/url.go
+++ b/utils/url.go
@@ -19,6 +19,8 @@ func OpenURL(url string) error {
 		cmd = exec.Command("open", url)
 	case "linux":
 		cmd = exec.Command("xdg-open", url)
+	case "freebsd":
+		cmd = exec.Command("xdg-open", url)
 
 	default:
 		return fmt.Errorf("unsupported platform")


### PR DESCRIPTION
Hi. Nice tool you've made! :star: :100: 

I do want to package `gowall` for FreeBSD platform that I am daily driving. I did sent a [port request](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=282799) to FreeBSD bugzilla and waiting for it to get accepted into FreeBSD repositories and ports tree soon.

I made two patches locally that adds FreeBSD platform support by editing those two files: `utils/url.go` and `internal/image/image.go`. After added FreeBSD support, `gowall` seems to work on FreeBSD.

I made these changes in my fork and created this PR. Also attached it as a `txt` file.
 
[patch.txt](https://github.com/user-attachments/files/17787316/patch.txt)

in case of "linux", it seems to use `xdg-open` and that's already available on FreeBSD. I added a "freebsd" case with same command.

Thanks in advance.
