### PR TITLE
feat: add convert completion for theme flag

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -110,6 +110,10 @@ var convertCmd = &cobra.Command{
 	},
 }
 
+func themeCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return image.ListThemes(), cobra.ShellCompDirectiveNoFileComp
+}
+
 func init() {
 	rootCmd.AddCommand(convertCmd)
 	convertCmd.Flags().StringVarP(&shared.Theme, "theme", "t", "catppuccin", "Usage : --theme [ThemeName]")
@@ -117,4 +121,6 @@ func init() {
 	convertCmd.Flags().StringVarP(&formatFlag, "format", "f", "", "Usage: --format [Extension]")
 	convertCmd.Flags().StringSliceVarP(&colorPair, "replace", "r", nil, "Usage: --replace #FromColor,#ToColor")
 	convertCmd.Flags().StringVarP(&outputName, "output", "o", "", "Usage: --output imageName (no extension) Can only be used alongside with -t,-r,-f flags")
+
+	convertCmd.RegisterFlagCompletionFunc("theme", themeCompletion)
 }


### PR DESCRIPTION
## Changelog
- Adds a basic completion function for themes when using the convert command

![demo](https://github.com/user-attachments/assets/c7e5df3a-a572-4fc5-b623-246b99f37aba)

Unrelated, but I noticed you were looking for some mac users to test features before. If that need ever comes up again, feel free to ping me, I'd love to help :)