### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 # Overview :framed_picture:
 
-Gowall is a tool to convert an image ( specifically a wallpaper ) to any color-scheme / pallete you like!
+Gowall is a tool to convert an image ( specifically a wallpaper ) to any color-scheme / palette you like!
 It also offers a bunch of image processing features (image to pixel art, Image upscaling, color palette extraction...)
 
 ## Docs 
@@ -134,7 +134,7 @@ Notes 🗒️ :
 # Usage :gear:
 
 
-1.  `Singe conversion`
+1.  `Single conversion`
 
   ```bash
     gowall convert path/to/img.png -t <theme-name>
@@ -218,9 +218,9 @@ Notes 🗒️ :
    <br>
 
 
-8.  `Pallete extraction` ( Like pywal )
+8.  `Palette extraction` ( Like pywal )
 
-    You can extract the color pallete of an image as shown below : 
+    You can extract the color palette of an image as shown below : 
 
     ```bash
     gowall extract /path/to/img.png -c 6

--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -20,8 +20,8 @@ var previewFlag bool
 // extractCmd represents the extract command
 var extractCmd = &cobra.Command{
 	Use:   "extract [FILE]",
-	Short: "Returns the color pallete of the image you specificed (like pywal)",
-	Long:  `Using the colorthief backend ( like pywal ) it returns the color pallete of the image (path) you specified`,
+	Short: "Returns the color palette of the image you specified (like pywal)",
+	Long:  `Using the colorthief backend ( like pywal ) it returns the color palette of the image (path) you specified`,
 	Run: func(cmd *cobra.Command, args []string) {
 
 		switch {

--- a/config/config.go
+++ b/config/config.go
@@ -36,7 +36,7 @@ func init() {
 	if err != nil {
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
-			// cant find home or config just give up
+			// can't find home or config just give up
 			return
 		}
 		configDir = filepath.Join(homeDir, ".config")
@@ -44,7 +44,7 @@ func init() {
 	configPath := filepath.Join(configDir, "gowall", configFile)
 
 	if _, err = os.Stat(configPath); errors.Is(err, os.ErrNotExist) {
-		// file doesnt exist skip custom themes
+		// file doesn't exist skip custom themes
 		return
 	}
 

--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -215,7 +215,7 @@ func DefaultProcessOptions() ProcessOptions {
 	}
 }
 
-// Processes the image depending on a processor that impliments the "ImageProcessor" interface.
+// Processes the image depending on a processor that implements the "ImageProcessor" interface.
 // You can pass an optional  "ProcessOptions" struct with extra options.
 func ProcessImg(imgPath string, processor ImageProcessor, theme string, opts ...ProcessOptions) (string, *image.Image, error) {
 	// Use default options if none provided

--- a/internal/image/removeBg.go
+++ b/internal/image/removeBg.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 )
 
-// impliments the ImageProcessor interface
+// implements the ImageProcessor interface
 type BackgroundProcessor struct {
 	options BgOptions
 }
@@ -163,7 +163,7 @@ func removeBackground(config *BgOptions, img image.Image) (error, image.Image) {
 			clusters[i].Centroid = newCentroid
 		}
 
-		// Convergence should be met when the colors stabalized
+		// Convergence should be met when the colors stabilized
 		if maxChange < config.Convergence {
 			break
 		}

--- a/utils/error.go
+++ b/utils/error.go
@@ -23,7 +23,7 @@ func HandleError(err error, msg ...string) {
 	}
 }
 
-// Formats a slice of errors to a single error, each seperated by a new line
+// Formats a slice of errors to a single error, each separated by a new line
 func FormatErrors(errs []error) string {
 	var result string
 	for _, err := range errs {


### PR DESCRIPTION
Found via `codespell -H`