### PR TITLE
feat: install with homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,11 @@ cd void-packages/
 ./xbps-src pkg gowall
 sudo xbps-install -R hostdir/binpkgs gowall
 ```
+### Homebrew - (Maintainer : [MillerApps](https://github.com/millerapps/))
+
+```
+brew install millerapps/tap/gowall
+```
 
 ### Build from source
 


### PR DESCRIPTION
## What's changed
📦 Added Homebrew installation instructions using [personal tap](https://github.com/millerapps/homebrew-tap)

## Why
-  Simplifies installation process for macOS users
-  Provides a one-command setup method