### PR TITLE
chore: swtich to homebrew-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,10 +296,10 @@ cd void-packages/
 ./xbps-src pkg gowall
 sudo xbps-install -R hostdir/binpkgs gowall
 ```
-### Homebrew - (Maintainer : [MillerApps](https://github.com/millerapps/))
+### Homebrew - (Maintainer : [Homebrew-Core](https://github.com/Homebrew/homebrew-core/blob/b86ea8e19ae7bf087fab8e2d56cd623eec1e1cf9/Formula/g/gowall.rb))
 
 ```
-brew install millerapps/tap/gowall
+brew install gowall
 ```
 
 ### Build from source


### PR DESCRIPTION
As it turns out someone added gowall to the homebrew-core tap so this would be better to use. https://github.com/Homebrew/homebrew-core/blob/b86ea8e19ae7bf087fab8e2d56cd623eec1e1cf9/Formula/g/gowall.rb
https://formulae.brew.sh/formula/gowall