### PR TITLE
feat: kitty graphics inline (doesn't rely on kitten icat) #38

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.19.0 h1:q5f1RH2jigJ1MoAWp2KTp3gm5zAGFUTarQZ5U386+4o=
+golang.org/x/sys v0.19.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=

--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -165,6 +165,7 @@ func SaveUrlAsImg(url string) (string, error) {
 //
 //	If the terminal emulator "kitty" is running --> it will print the image on the terminal
 func OpenImage(filePath string) error {
+	fmt.Println("Open image")
 
 	if !config.GowallConfig.EnableImagePreviewing {
 		return nil
@@ -172,11 +173,15 @@ func OpenImage(filePath string) error {
 
 	var cmd *exec.Cmd
 
-	if utils.IsKittyTerminalRunning() || utils.IsKonsoleTerminalRunning() || utils.IsGhosttyTerminalRunning() {
+	if utils.IsKittyTerminalRunning() || utils.IsKonsoleTerminalRunning() {
 		cmd = exec.Command("kitty", "icat", filePath)
 		cmd.Stdout = os.Stdout
 
 		return cmd.Run()
+	}
+
+	 if utils.IsGhosttyTerminalRunning() {
+		return utils.SendKittyImg(filePath)
 	}
 
 	if utils.IsWeztermTerminalRunning() {

--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -157,7 +157,6 @@ func SaveUrlAsImg(url string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("could not write to file: %w", err)
 	}
-	fmt.Printf("path: %v", path)
 	return path, nil
 }
 

--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -157,7 +157,7 @@ func SaveUrlAsImg(url string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("could not write to file: %w", err)
 	}
-
+	fmt.Printf("path: %v", path)
 	return path, nil
 }
 
@@ -173,14 +173,14 @@ func OpenImage(filePath string) error {
 
 	var cmd *exec.Cmd
 
-	if utils.IsKittyTerminalRunning() || utils.IsKonsoleTerminalRunning() {
+	if utils.IsKittyTerminalRunning() {
 		cmd = exec.Command("kitty", "icat", filePath)
 		cmd.Stdout = os.Stdout
 
 		return cmd.Run()
 	}
 
-	 if utils.IsGhosttyTerminalRunning() {
+	if utils.IsGhosttyTerminalRunning() || utils.IsKonsoleTerminalRunning() {
 		return utils.SendKittyImg(filePath)
 	}
 

--- a/utils/checks.go
+++ b/utils/checks.go
@@ -34,21 +34,15 @@ func IsKonsoleTerminalRunning() bool {
 	return false
 }
 
-// Checks if the terminal running is Konsole and has
+// Checks if the terminal running is Ghostty and has
 func IsGhosttyTerminalRunning() bool {
 
 	terminal := os.Getenv("TERM")
-
-	if terminal == "xterm-ghostty" && os.Getenv("TERM_PROGRAM") == "ghostty" {
-
-		path, err := exec.LookPath("kitten")
-		if err != nil {
-			return false
-		}
-
-		return path != ""
-
+	
+	if strings.Contains(terminal, "ghostty") {
+		return true
 	}
+
 	return false
 }
 

--- a/utils/checks.go
+++ b/utils/checks.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 )
 
@@ -22,14 +21,7 @@ func IsKonsoleTerminalRunning() bool {
 	terminal := os.Getenv("TERM")
 
 	if terminal == "xterm-256color" && os.Getenv("KONSOLE_VERSION") != "" {
-
-		path, err := exec.LookPath("kitten")
-		if err != nil {
-			return false
-		}
-
-		return path != ""
-
+		return true
 	}
 	return false
 }
@@ -38,7 +30,7 @@ func IsKonsoleTerminalRunning() bool {
 func IsGhosttyTerminalRunning() bool {
 
 	terminal := os.Getenv("TERM")
-	
+
 	if strings.Contains(terminal, "ghostty") {
 		return true
 	}

--- a/utils/sendKittyImg.go
+++ b/utils/sendKittyImg.go
@@ -8,45 +8,128 @@ import (
 	"image/png"
 	"io"
 	"os"
+
+	"golang.org/x/sys/unix"
 )
 
-// SendKittyImg sends a file as a Kitty protocol inline image without any extra output.
-// The escape sequence is formatted per the spec: begins with ESC _ G, parameters terminated with a semicolon,
-// then the base64 data, and finally terminated with ESC \.
+// SendKittyImg sends a file as a Kitty protocol image with aspect-ratio scaling,
+// writing directly to /dev/tty to avoid interference from terminal input/output.
 func SendKittyImg(filePath string) error {
-	// Open the file.
+	// Open the image file.
 	f, err := os.Open(filePath)
 	if err != nil {
-		return fmt.Errorf("Error opening image file")
+		return fmt.Errorf("error opening image file: %w", err)
 	}
 	defer f.Close()
-
 	// Turns out the kitty graphics protocol prefers PNG
 	// https://sw.kovidgoyal.net/kitty/graphics-protocol/#png-data
 	// so we Decode the image (this works for JPEG, PNG, GIF, etc.) from the filePath
 	img, _, err := image.Decode(f)
 	if err != nil {
-		return fmt.Errorf("Error decoding image")
+		return fmt.Errorf("error decoding image: %w", err)
 	}
 
 	// Create an in-memory buffer to hold the PNG-encoded image.
 	// This will be a temporary place in memory simply to easily show an inline preview
 	var buf bytes.Buffer
 	if err := png.Encode(&buf, img); err != nil {
-		return fmt.Errorf("Error encoding to buffer")
+		return fmt.Errorf("error encoding PNG: %w", err)
 	}
 
-	// Begin the inline image sequence with the correct parameter termination.
-	fmt.Printf("\x1b_Gf=100,a=T;")
+	intRows, intCols := computeDesiredTextSize(img)
 
-	// Base64-encode the file contents directly to stdout.
-	encoder := base64.NewEncoder(base64.StdEncoding, os.Stdout)
+	// Open /dev/tty for writing to avoid interference.
+	ttyWriter, err := os.OpenFile("/dev/tty", int(unix.O_WRONLY|unix.O_NOCTTY), 0)
+	if err != nil {
+		return fmt.Errorf("error opening /dev/tty for writing: %w", err)
+	}
+	defer ttyWriter.Close()
+
+	// Begin the Kitty image escape sequence.
+	// a=T is the documented mode (non-scrolling) and we use text-cell sizing (r and c).
+	_, err = fmt.Fprintf(ttyWriter, "\x1b_Gf=100,a=T,X=100,r=%d,c=%d;", intRows, intCols)
+	if err != nil {
+		return fmt.Errorf("error writing escape sequence: %w", err)
+	}
+
+	// Base64-encode the PNG data directly to ttyWriter.
+	encoder := base64.NewEncoder(base64.StdEncoding, ttyWriter)
 	if _, err := io.Copy(encoder, &buf); err != nil {
-		return fmt.Errorf("Error base64 encoding")
+		return fmt.Errorf("error base64 encoding image data: %w", err)
 	}
 	encoder.Close()
 
 	// Terminate the escape sequence including newline.
-	fmt.Printf("\x1b\\\n")
+	_, err = fmt.Fprintf(ttyWriter, "\x1b\\\n")
+	if err != nil {
+		return fmt.Errorf("error writing final escape sequence: %w", err)
+	}
+
 	return nil
+}
+
+// getTerminalDimensions returns the terminal's text cell dimensions (rows, cols)
+// and its pixel dimensions (width, height) by querying /dev/tty.
+func getTerminalDimensions() (rows, cols, pxWidth, pxHeight int) {
+	tty, err := os.OpenFile("/dev/tty", int(unix.O_RDWR|unix.O_NOCTTY), 0)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error opening /dev/tty: %v\n", err)
+		os.Exit(1)
+	}
+	defer tty.Close()
+
+	sz, err := unix.IoctlGetWinsize(int(tty.Fd()), unix.TIOCGWINSZ)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error getting window size: %v\n", err)
+		os.Exit(1)
+	}
+
+	return int(sz.Row), int(sz.Col), int(sz.Xpixel), int(sz.Ypixel)
+}
+
+// getImageAspect returns the images og dimensions/aspect ratio
+func getImageAspect(img image.Image) float64 {
+
+	// Get original image dimensions (in pixels)
+	imgWidth := img.Bounds().Dx()
+	imgHeight := img.Bounds().Dy()
+
+	// image pixel aspect ratio.
+	return float64(imgWidth) / float64(imgHeight)
+}
+
+// computeDesiredTextSize calculates and returns the desired number of text cells (r and c)
+// that should be used for the image, preserving its aspect ratio.
+// It uses both the image dimensions and the terminal's text and pixel dimensions.
+func computeDesiredTextSize(img image.Image) (int, int) {
+	// Get terminal size: text cells and pixel dimensions.
+	termRows, termCols, termPxWidth, termPxHeight := getTerminalDimensions()
+
+	// Get image aspect ratio.
+	imgAspect := getImageAspect(img)
+
+	// Compute the size of one cell (in pixels).
+	cellWidth := float64(termPxWidth) / float64(termCols)
+	cellHeight := float64(termPxHeight) / float64(termRows)
+	cellAspect := cellWidth / cellHeight
+
+	// Adjust image aspect ratio to account for the non-square text cells.
+	effectiveAspect := imgAspect / cellAspect
+
+	// Use 90% of available text cells as the maximum.
+	maxCols := float64(termCols) * 0.9
+	maxRows := float64(termRows) * 0.9
+
+	// Start with the maximum width and compute the height from the effective aspect ratio.
+	desiredCols := maxCols
+	desiredRows := desiredCols / effectiveAspect
+
+	// If the computed rows exceed the maximum available, recalc based on height.
+	if desiredRows > maxRows {
+		desiredRows = maxRows
+		desiredCols = desiredRows * effectiveAspect
+	}
+
+	// Return as integers.
+	return int(desiredRows), int(desiredCols)
 }

--- a/utils/sendKittyImg.go
+++ b/utils/sendKittyImg.go
@@ -1,0 +1,35 @@
+package utils
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io"
+	"os"
+)
+
+// SendKittyImg sends a file as a Kitty protocol inline image without any extra output.
+// The escape sequence is formatted per the spec: begins with ESC _ G, parameters terminated with a semicolon,
+// then the base64 data, and finally terminated with ESC \.
+func SendKittyImg(filePath string) error {
+	// Open the file.
+	f, err := os.Open(filePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// Begin the inline image sequence with the correct parameter termination.
+	fmt.Printf("\x1b_Gf=100,a=T;")
+	
+	// Base64-encode the file contents directly to stdout.
+	encoder := base64.NewEncoder(base64.StdEncoding, os.Stdout)
+	if _, err := io.Copy(encoder, f); err != nil {
+		return err
+	}
+	encoder.Close()
+
+	// Terminate the escape sequence correctly.
+	fmt.Printf("\x1b\\\n")
+	return nil
+}
+

--- a/utils/sendKittyImg.go
+++ b/utils/sendKittyImg.go
@@ -1,8 +1,11 @@
 package utils
 
 import (
+	"bytes"
 	"encoding/base64"
 	"fmt"
+	"image"
+	"image/png"
 	"io"
 	"os"
 )
@@ -14,22 +17,36 @@ func SendKittyImg(filePath string) error {
 	// Open the file.
 	f, err := os.Open(filePath)
 	if err != nil {
-		return err
+		return fmt.Errorf("Error opening image file")
 	}
 	defer f.Close()
 
+	// Turns out the kitty graphics protocol prefers PNG
+	// https://sw.kovidgoyal.net/kitty/graphics-protocol/#png-data
+	// so we Decode the image (this works for JPEG, PNG, GIF, etc.) from the filePath
+	img, _, err := image.Decode(f)
+	if err != nil {
+		return fmt.Errorf("Error decoding image")
+	}
+
+	// Create an in-memory buffer to hold the PNG-encoded image.
+	// This will be a temporary place in memory simply to easily show an inline preview
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		return fmt.Errorf("Error encoding to buffer")
+	}
+
 	// Begin the inline image sequence with the correct parameter termination.
 	fmt.Printf("\x1b_Gf=100,a=T;")
-	
+
 	// Base64-encode the file contents directly to stdout.
 	encoder := base64.NewEncoder(base64.StdEncoding, os.Stdout)
-	if _, err := io.Copy(encoder, f); err != nil {
-		return err
+	if _, err := io.Copy(encoder, &buf); err != nil {
+		return fmt.Errorf("Error base64 encoding")
 	}
 	encoder.Close()
 
-	// Terminate the escape sequence correctly.
+	// Terminate the escape sequence including newline.
 	fmt.Printf("\x1b\\\n")
 	return nil
 }
-


### PR DESCRIPTION
Adds basic inline image previews that no longer use `kitten icat`

Tested and working in Ghostty. I'm on macOS, so I have not tested it in Konsole. Based on Konsole being listed as supported [here](https://sw.kovidgoyal.net/kitty/graphics-protocol/#png-datal), my assumption is that it should work like Ghostty.

![CleanShot 2025-02-21 at 16 46 31](https://github.com/user-attachments/assets/39e232af-bae9-4966-b4f1-7cf20522d166)

closes #38