### PR TITLE
 Inline Image preview 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,7 @@ type themeWrapper struct {
 
 type Options struct {
 	EnableImagePreviewing  bool           `yaml:"EnableImagePreviewing"`
+	InlineImagePreview     bool           `yaml:"InlineImagePreview"`
 	ColorCorrectionBackend string         `yaml:"ColorCorrectionBackend"`
 	OutputFolder           string         `yaml:"OutputFolder"`
 	Themes                 []themeWrapper `yaml:"themes"`

--- a/config/constants.go
+++ b/config/constants.go
@@ -11,6 +11,7 @@ const (
 
 var (
 	EnableImagePreviewingDefault = true
+	InlineImagePreviewDefault    = false
 	ThemesDefault                = []themeWrapper{}
 )
 
@@ -18,5 +19,6 @@ func defaultConfig() Options {
 	return Options{
 		EnableImagePreviewing: EnableImagePreviewingDefault,
 		Themes:                ThemesDefault,
+		InlineImagePreview:    InlineImagePreviewDefault,
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.9.2
 	github.com/spf13/cobra v1.8.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
+	golang.org/x/term v0.19.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -15,4 +16,5 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/net v0.24.0 // indirect
+	golang.org/x/sys v0.19.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -36,10 +36,14 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.19.0 h1:q5f1RH2jigJ1MoAWp2KTp3gm5zAGFUTarQZ5U386+4o=
+golang.org/x/sys v0.19.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
 golang.org/x/term v0.7.0/go.mod h1:P32HKFT3hSsZrRxla30E9HqToFYAQPCMs/zFMBUFqPY=
+golang.org/x/term v0.19.0 h1:+ThwsDv+tYfnJFhF4L8jITxu1tdTWRTZpdsWgEgjL6Q=
+golang.org/x/term v0.19.0/go.mod h1:2CuTdWZ7KHSQwUzKva0cbMg6q2DMI3Mmxp+gKJbskEk=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/terminal/checks.go
+++ b/terminal/checks.go
@@ -1,0 +1,59 @@
+package terminal
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// Checks if the terminal using gowall is the kitty terminal emulator
+func IsKittyTerminalRunning() bool {
+
+	terminal := os.Getenv("TERM")
+	kittyInstanceId := os.Getenv("KITTY_WINDOW_ID")
+
+	return strings.Contains(terminal, "kitty") || kittyInstanceId != ""
+}
+
+// Checks if the terminal running is Konsole
+func IsKonsoleTerminalRunning() bool {
+
+	terminal := os.Getenv("TERM")
+
+	if terminal == "xterm-256color" && os.Getenv("KONSOLE_VERSION") != "" {
+		return true
+	}
+	return false
+}
+
+// Checks if the terminal running is Ghostty
+func IsGhosttyTerminalRunning() bool {
+
+	terminal := os.Getenv("TERM")
+
+	if terminal == "xterm-ghostty" && os.Getenv("TERM_PROGRAM") == "ghostty" {
+		return true
+	}
+	return false
+}
+
+// Checks if the terminal running is Wezterm
+func IsWeztermTerminalRunning() bool {
+
+	terminal := os.Getenv("TERM")
+
+	if terminal == "xterm-256color" && os.Getenv("TERM_PROGRAM") == "WezTerm" {
+		return true
+	}
+	return false
+}
+
+// Checks if the user has the kitten binary installed, so the kitten icat image utility can be used
+func HasIcat() bool {
+	path, err := exec.LookPath("kitten")
+	if err != nil {
+		return false
+	}
+
+	return path != ""
+}

--- a/terminal/terminal.go
+++ b/terminal/terminal.go
@@ -1,0 +1,44 @@
+package terminal
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"image"
+	"image/png"
+	"io"
+	"os"
+)
+
+func RenderKittyImg(filePath string) error {
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		return err
+	}
+
+	defer file.Close()
+
+	img, _, err := image.Decode(file)
+	if err != nil {
+		return err
+	}
+
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		return fmt.Errorf("while encoding to buffer")
+	}
+
+	// Begin the inline image sequence with the correct parameter termination.
+	fmt.Printf("\x1b_Gf=100,a=T;")
+
+	encoder := base64.NewEncoder(base64.StdEncoding, os.Stdout)
+	if _, err := io.Copy(encoder, &buf); err != nil {
+		return fmt.Errorf("while base64 encoding")
+	}
+	encoder.Close()
+
+	// Terminate the escape sequence including newline.
+	fmt.Printf("\x1b\\\n")
+	return nil
+}

--- a/terminal/terminal.go
+++ b/terminal/terminal.go
@@ -14,68 +14,67 @@ import (
 	"golang.org/x/term"
 )
 
-// RenderKittyImg sends a file as a Kitty protocol image with aspect-ratio scaling,
-// writing directly to /dev/tty to avoid interference from terminal input/output.
+// RenderKittyImg renders an image with the Kitty protocol and aspect-ratio scaling,
 func RenderKittyImg(filePath string) error {
 
 	file, err := os.Open(filePath)
 	if err != nil {
-		return fmt.Errorf("error opening image file: %w", err)
+		return fmt.Errorf("opening image file: %w", err)
 	}
 	defer file.Close()
 
 	img, _, err := image.Decode(file)
 	if err != nil {
-		return fmt.Errorf("error decoding image: %w", err)
+		return fmt.Errorf("decoding image: %w", err)
 	}
 
 	var buf bytes.Buffer
 	if err := png.Encode(&buf, img); err != nil {
-		return fmt.Errorf("error encoding PNG: %w", err)
+		return fmt.Errorf("encoding PNG: %w", err)
 	}
 
-	// Calculate dimensions in text cells
-	intRows, intCols := computeDesiredTextSize(img)
+	intRows, intCols, err := textCells(img)
+	if err != nil {
+		return err
+	}
 
-	// Open terminal for direct writing
 	ttyWriter, err := os.OpenFile("/dev/tty", os.O_WRONLY, 0)
 	if err != nil {
-		return fmt.Errorf("error opening /dev/tty: %w", err)
+		return fmt.Errorf("opening /dev/tty: %w", err)
 	}
 	defer ttyWriter.Close()
 
 	// Start Kitty image protocol sequence
-	_, err = fmt.Fprintf(ttyWriter, "\x1b_Gf=100,a=T,r=%d,c=%d;", intRows, intCols)
-	if err != nil {
-		return fmt.Errorf("error writing header: %w", err)
+	header := fmt.Sprintf("\x1b_Gf=100,a=T,r=%d,c=%d;", intRows, intCols)
+	if _, err := io.WriteString(ttyWriter, header); err != nil {
+		return fmt.Errorf("writing header: %w", err)
 	}
 
-	// Stream base64-encoded image data
 	encoder := base64.NewEncoder(base64.StdEncoding, ttyWriter)
 	if _, err := io.Copy(encoder, &buf); err != nil {
-		return fmt.Errorf("error writing image data: %w", err)
+		encoder.Close()
+		return fmt.Errorf("writing image data: %w", err)
 	}
-	encoder.Close()
+	if err := encoder.Close(); err != nil {
+		return fmt.Errorf("closing encoder: %w", err)
+	}
 
 	// Terminate the image sequence
-	_, err = fmt.Fprintf(ttyWriter, "\x1b\\\n")
-	if err != nil {
-		return fmt.Errorf("error writing footer: %w", err)
+	if _, err := io.WriteString(ttyWriter, "\x1b\\\n"); err != nil {
+		return fmt.Errorf("writing footer: %w", err)
 	}
 
 	return nil
 }
 
-// getTerminalDimensions retrieves terminal size in text cells and pixels
-func getTerminalDimensions() (rows, cols, pxWidth, pxHeight int) {
+// getTerminalDimensions retrieves terminal size in text cells needed for the kitty protocol and pixels
+func getTerminalDimensions() (rows, cols, pxWidth, pxHeight int, err error) {
 	// Open /dev/tty for Linux & MacOS , CONOUT$ on Windows
-	// for writing
 	ttyWrite, err := os.OpenFile("CONOUT$", os.O_WRONLY, 0)
 	if err != nil {
 		ttyWrite, err = os.OpenFile("/dev/tty", os.O_WRONLY, 0)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "failed to open terminal for writing: %v\n", err)
-			os.Exit(1)
+			return 0, 0, 0, 0, fmt.Errorf("failed to open tty for writing: %w", err)
 		}
 	}
 	defer ttyWrite.Close()
@@ -85,8 +84,7 @@ func getTerminalDimensions() (rows, cols, pxWidth, pxHeight int) {
 	if err != nil {
 		ttyRead, err = os.OpenFile("/dev/tty", os.O_RDONLY, 0)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "failed to open terminal for reading: %v\n", err)
-			os.Exit(1)
+			return 0, 0, 0, 0, fmt.Errorf("failed to open tty for reading: %w", err)
 		}
 	}
 	defer ttyRead.Close()
@@ -94,19 +92,17 @@ func getTerminalDimensions() (rows, cols, pxWidth, pxHeight int) {
 	// Switch to raw mode and ensure it gets restored
 	oldState, err := term.MakeRaw(int(ttyRead.Fd()))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to set raw mode: %v\n", err)
-		os.Exit(1)
+		return 0, 0, 0, 0, fmt.Errorf("failed to set raw mode: %w", err)
 	}
 	defer term.Restore(int(ttyRead.Fd()), oldState)
 
 	// query the terminal for its dimensions via ANSI escape codes
 	_, err = ttyWrite.Write([]byte("\033[18t\033[14t"))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write to terminal: %v\n", err)
-		os.Exit(1)
+		return 0, 0, 0, 0, fmt.Errorf("failed to set raw mode: %w", err)
 	}
 
-	// Read responses
+	// Read response
 	var buf [32]byte
 	var response []byte
 	for {
@@ -120,7 +116,6 @@ func getTerminalDimensions() (rows, cols, pxWidth, pxHeight int) {
 		}
 	}
 
-	// Parse text dimensions
 	reText := regexp.MustCompile(`\033\[8;(\d+);(\d+)t`)
 	matchesText := reText.FindStringSubmatch(string(response))
 	if len(matchesText) == 3 {
@@ -128,7 +123,6 @@ func getTerminalDimensions() (rows, cols, pxWidth, pxHeight int) {
 		cols, _ = strconv.Atoi(matchesText[2])
 	}
 
-	// Parse pixel dimensions
 	rePixel := regexp.MustCompile(`\033\[4;(\d+);(\d+)t`)
 	matchesPixel := rePixel.FindStringSubmatch(string(response))
 	if len(matchesPixel) == 3 {
@@ -136,29 +130,26 @@ func getTerminalDimensions() (rows, cols, pxWidth, pxHeight int) {
 		pxWidth, _ = strconv.Atoi(matchesPixel[2])
 	}
 
-	return
+	return rows, cols, pxWidth, pxHeight, nil
 }
 
-// getImageAspect returns the images og dimensions/aspect ratio
-func getImageAspect(img image.Image) float64 {
-
-	// Get original image dimensions (in pixels)
+// aspectRatio returns the aspect ratio of the image
+func aspectRatio(img image.Image) float64 {
 	imgWidth := img.Bounds().Dx()
 	imgHeight := img.Bounds().Dy()
 
-	// image pixel aspect ratio.
 	return float64(imgWidth) / float64(imgHeight)
 }
 
-// computeDesiredTextSize calculates and returns the desired number of text cells (r and c)
+// textCells calculates and returns the desired number of text cells (r and c)
 // that should be used for the image, preserving its aspect ratio.
-// It uses both the image dimensions and the terminal's text and pixel dimensions.
-func computeDesiredTextSize(img image.Image) (int, int) {
-	// Get terminal size: text cells and pixel dimensions.
-	termRows, termCols, termPxWidth, termPxHeight := getTerminalDimensions()
+func textCells(img image.Image) (int, int, error) {
+	termRows, termCols, termPxWidth, termPxHeight, err := getTerminalDimensions()
+	if err != nil {
+		return 0, 0, fmt.Errorf("while getting terminal dimensions: %w", err)
+	}
 
-	// Get image aspect ratio.
-	imgAspect := getImageAspect(img)
+	imgAspect := aspectRatio(img)
 
 	// Compute the size of one cell (in pixels).
 	cellWidth := float64(termPxWidth) / float64(termCols)
@@ -182,6 +173,5 @@ func computeDesiredTextSize(img image.Image) (int, int) {
 		desiredCols = desiredRows * effectiveAspect
 	}
 
-	// Return as integers.
-	return int(desiredRows), int(desiredCols)
+	return int(desiredRows), int(desiredCols), nil
 }

--- a/terminal/terminal.go
+++ b/terminal/terminal.go
@@ -8,37 +8,180 @@ import (
 	"image/png"
 	"io"
 	"os"
+	"regexp"
+	"strconv"
+
+	"golang.org/x/term"
 )
 
+// RenderKittyImg sends a file as a Kitty protocol image with aspect-ratio scaling,
+// writing directly to /dev/tty to avoid interference from terminal input/output.
 func RenderKittyImg(filePath string) error {
 
 	file, err := os.Open(filePath)
 	if err != nil {
-		return err
+		return fmt.Errorf("error opening image file: %w", err)
 	}
-
 	defer file.Close()
 
 	img, _, err := image.Decode(file)
 	if err != nil {
-		return err
+		return fmt.Errorf("error decoding image: %w", err)
 	}
 
 	var buf bytes.Buffer
 	if err := png.Encode(&buf, img); err != nil {
-		return fmt.Errorf("while encoding to buffer")
+		return fmt.Errorf("error encoding PNG: %w", err)
 	}
 
-	// Begin the inline image sequence with the correct parameter termination.
-	fmt.Printf("\x1b_Gf=100,a=T;")
+	// Calculate dimensions in text cells
+	intRows, intCols := computeDesiredTextSize(img)
 
-	encoder := base64.NewEncoder(base64.StdEncoding, os.Stdout)
+	// Open terminal for direct writing
+	ttyWriter, err := os.OpenFile("/dev/tty", os.O_WRONLY, 0)
+	if err != nil {
+		return fmt.Errorf("error opening /dev/tty: %w", err)
+	}
+	defer ttyWriter.Close()
+
+	// Start Kitty image protocol sequence
+	_, err = fmt.Fprintf(ttyWriter, "\x1b_Gf=100,a=T,r=%d,c=%d;", intRows, intCols)
+	if err != nil {
+		return fmt.Errorf("error writing header: %w", err)
+	}
+
+	// Stream base64-encoded image data
+	encoder := base64.NewEncoder(base64.StdEncoding, ttyWriter)
 	if _, err := io.Copy(encoder, &buf); err != nil {
-		return fmt.Errorf("while base64 encoding")
+		return fmt.Errorf("error writing image data: %w", err)
 	}
 	encoder.Close()
 
-	// Terminate the escape sequence including newline.
-	fmt.Printf("\x1b\\\n")
+	// Terminate the image sequence
+	_, err = fmt.Fprintf(ttyWriter, "\x1b\\\n")
+	if err != nil {
+		return fmt.Errorf("error writing footer: %w", err)
+	}
+
 	return nil
+}
+
+// getTerminalDimensions retrieves terminal size in text cells and pixels
+func getTerminalDimensions() (rows, cols, pxWidth, pxHeight int) {
+	// Open /dev/tty for Linux & MacOS , CONOUT$ on Windows
+	// for writing
+	ttyWrite, err := os.OpenFile("CONOUT$", os.O_WRONLY, 0)
+	if err != nil {
+		ttyWrite, err = os.OpenFile("/dev/tty", os.O_WRONLY, 0)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to open terminal for writing: %v\n", err)
+			os.Exit(1)
+		}
+	}
+	defer ttyWrite.Close()
+
+	// Open terminal for reading responses
+	ttyRead, err := os.OpenFile("CONOUT$", os.O_RDONLY, 0)
+	if err != nil {
+		ttyRead, err = os.OpenFile("/dev/tty", os.O_RDONLY, 0)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to open terminal for reading: %v\n", err)
+			os.Exit(1)
+		}
+	}
+	defer ttyRead.Close()
+
+	// Switch to raw mode and ensure it gets restored
+	oldState, err := term.MakeRaw(int(ttyRead.Fd()))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to set raw mode: %v\n", err)
+		os.Exit(1)
+	}
+	defer term.Restore(int(ttyRead.Fd()), oldState)
+
+	// query the terminal for its dimensions via ANSI escape codes
+	_, err = ttyWrite.Write([]byte("\033[18t\033[14t"))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to write to terminal: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Read responses
+	var buf [32]byte
+	var response []byte
+	for {
+		n, err := ttyRead.Read(buf[:])
+		if err != nil || n == 0 {
+			break
+		}
+		response = append(response, buf[:n]...)
+		if bytes.Count(response, []byte("t")) >= 2 {
+			break
+		}
+	}
+
+	// Parse text dimensions
+	reText := regexp.MustCompile(`\033\[8;(\d+);(\d+)t`)
+	matchesText := reText.FindStringSubmatch(string(response))
+	if len(matchesText) == 3 {
+		rows, _ = strconv.Atoi(matchesText[1])
+		cols, _ = strconv.Atoi(matchesText[2])
+	}
+
+	// Parse pixel dimensions
+	rePixel := regexp.MustCompile(`\033\[4;(\d+);(\d+)t`)
+	matchesPixel := rePixel.FindStringSubmatch(string(response))
+	if len(matchesPixel) == 3 {
+		pxHeight, _ = strconv.Atoi(matchesPixel[1])
+		pxWidth, _ = strconv.Atoi(matchesPixel[2])
+	}
+
+	return
+}
+
+// getImageAspect returns the images og dimensions/aspect ratio
+func getImageAspect(img image.Image) float64 {
+
+	// Get original image dimensions (in pixels)
+	imgWidth := img.Bounds().Dx()
+	imgHeight := img.Bounds().Dy()
+
+	// image pixel aspect ratio.
+	return float64(imgWidth) / float64(imgHeight)
+}
+
+// computeDesiredTextSize calculates and returns the desired number of text cells (r and c)
+// that should be used for the image, preserving its aspect ratio.
+// It uses both the image dimensions and the terminal's text and pixel dimensions.
+func computeDesiredTextSize(img image.Image) (int, int) {
+	// Get terminal size: text cells and pixel dimensions.
+	termRows, termCols, termPxWidth, termPxHeight := getTerminalDimensions()
+
+	// Get image aspect ratio.
+	imgAspect := getImageAspect(img)
+
+	// Compute the size of one cell (in pixels).
+	cellWidth := float64(termPxWidth) / float64(termCols)
+	cellHeight := float64(termPxHeight) / float64(termRows)
+	cellAspect := cellWidth / cellHeight
+
+	// Adjust image aspect ratio to account for the non-square text cells.
+	effectiveAspect := imgAspect / cellAspect
+
+	// Use 90% of available text cells as the maximum.
+	maxCols := float64(termCols) * 0.9
+	maxRows := float64(termRows) * 0.9
+
+	// Start with the maximum width and compute the height from the effective aspect ratio.
+	desiredCols := maxCols
+	desiredRows := desiredCols / effectiveAspect
+
+	// If the computed rows exceed the maximum available, recalc based on height.
+	if desiredRows > maxRows {
+		desiredRows = maxRows
+		desiredCols = desiredRows * effectiveAspect
+	}
+
+	// Return as integers.
+	return int(desiredRows), int(desiredCols)
 }

--- a/utils/checks.go
+++ b/utils/checks.go
@@ -2,65 +2,8 @@ package utils
 
 import (
 	"fmt"
-	"os"
-	"os/exec"
 	"strings"
 )
-
-// Checks if the terminal using gowall is the kitty terminal emulator
-func IsKittyTerminalRunning() bool {
-
-	terminal := os.Getenv("TERM")
-	kittyInstanceId := os.Getenv("KITTY_WINDOW_ID")
-
-	return strings.Contains(terminal, "kitty") || kittyInstanceId != ""
-}
-
-// Checks if the terminal running is Konsole and has
-func IsKonsoleTerminalRunning() bool {
-
-	terminal := os.Getenv("TERM")
-
-	if terminal == "xterm-256color" && os.Getenv("KONSOLE_VERSION") != "" {
-
-		path, err := exec.LookPath("kitten")
-		if err != nil {
-			return false
-		}
-
-		return path != ""
-
-	}
-	return false
-}
-
-// Checks if the terminal running is Konsole and has
-func IsGhosttyTerminalRunning() bool {
-
-	terminal := os.Getenv("TERM")
-
-	if terminal == "xterm-ghostty" && os.Getenv("TERM_PROGRAM") == "ghostty" {
-
-		path, err := exec.LookPath("kitten")
-		if err != nil {
-			return false
-		}
-
-		return path != ""
-
-	}
-	return false
-}
-
-func IsWeztermTerminalRunning() bool {
-
-	terminal := os.Getenv("TERM")
-
-	if terminal == "xterm-256color" && os.Getenv("TERM_PROGRAM") == "WezTerm" {
-		return true
-	}
-	return false
-}
 
 func Confirm(msg string) bool {
 


### PR DESCRIPTION
Adding the following option enables gowall to print images to the terminal without the `kitten icat` dependency.
The default value is `false` and it's not enabled by default since its experimental.

```yml
InlineImagePreview: true
```