### PR TITLE
feat: add shepard method backend

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,12 @@ type Options struct {
 	ColorCorrectionBackend string         `yaml:"ColorCorrectionBackend"`
 	OutputFolder           string         `yaml:"OutputFolder"`
 	Themes                 []themeWrapper `yaml:"themes"`
+	ShepardOptions         ShepardOptions `yaml:"shepardOptions"`
+}
+
+type ShepardOptions struct {
+	Nearest int     `yaml:"nearest"`
+	Power   float64 `yaml:"power"`
 }
 
 var GowallConfig = defaultConfig()

--- a/config/constants.go
+++ b/config/constants.go
@@ -7,20 +7,32 @@ const (
 	WallOfTheDayUrl    = "https://www.reddit.com/r/wallpaper/top/"
 	HexCodeVisualUrl   = "https://lawlesscreation.github.io/hex-color-visualiser/"
 	UpscalerBinaryName = "realesrgan-ncnn-vulkan"
+
+	BackendNN      = "nn"
+	BackendRBF     = "rbf"
+	BackendShepard = "shepard"
 )
 
 var (
-	EnableImagePreviewingDefault = true
-	InlineImagePreviewDefault    = false
-	ImagePreviewBackend          = ""
-	ThemesDefault                = []themeWrapper{}
+	EnableImagePreviewingDefault  = true
+	InlineImagePreviewDefault     = false
+	ImagePreviewBackend           = ""
+	ColorCorrectionBackendDefault = BackendRBF
+	ThemesDefault                 = []themeWrapper{}
+
+	ShepardOptionsDefault = ShepardOptions{
+		Nearest: 30,
+		Power:   4.0,
+	}
 )
 
 func defaultConfig() Options {
 	return Options{
-		EnableImagePreviewing: EnableImagePreviewingDefault,
-		Themes:                ThemesDefault,
-		InlineImagePreview:    InlineImagePreviewDefault,
-		ImagePreviewBackend:   ImagePreviewBackend,
+		EnableImagePreviewing:  EnableImagePreviewingDefault,
+		InlineImagePreview:     InlineImagePreviewDefault,
+		ImagePreviewBackend:    ImagePreviewBackend,
+		ColorCorrectionBackend: ColorCorrectionBackendDefault,
+		Themes:                 ThemesDefault,
+		ShepardOptions:         ShepardOptionsDefault,
 	}
 }

--- a/internal/backends/colorthief/haldClut/shepard.go
+++ b/internal/backends/colorthief/haldClut/shepard.go
@@ -1,0 +1,140 @@
+package haldclut
+
+import (
+	"image/color"
+	"math"
+	"sort"
+)
+
+type ShepardMapper struct {
+	options ShepardMapperOptions
+}
+
+type ShepardMapperOptions struct {
+	Nearest int
+	Power   float64
+}
+
+func NewShepardMapper(opts ShepardMapperOptions) *ShepardMapper {
+	return &ShepardMapper{options: opts}
+}
+
+func (m *ShepardMapper) Map(original color.RGBA, palette []color.RGBA) color.RGBA {
+	return shepardInterpolation(original, palette, m.options)
+}
+
+// Core Shepard's Method implementation
+func shepardInterpolation(originalRGBA color.RGBA, paletteRGBAs []color.RGBA, opts ShepardMapperOptions) color.RGBA {
+	if len(paletteRGBAs) == 0 {
+		return originalRGBA
+	}
+
+	// Find N closest colors based on original color
+	closest := findNClosestColors(originalRGBA, paletteRGBAs, opts.Nearest)
+	if len(closest) == 0 {
+		return originalRGBA
+	}
+
+	// If exact match or only one neighbor, return it
+	if len(closest) == 1 || closest[0].dist == 0 {
+		return closest[0].color
+	}
+
+	// Calculate inverse distance weights
+	weights := make([]float64, len(closest))
+	var totalWeight float64
+
+	for i, c := range closest {
+		if c.dist == 0 {
+			return c.color // Exact match found
+		}
+		weight := 1.0 / math.Pow(math.Sqrt(c.dist), opts.Power)
+		weights[i] = weight
+		totalWeight += weight
+	}
+
+	// Blend colors using inverse distance weights
+	blended := blendColors(extractColors(closest), weights)
+	return blended
+}
+
+func colorDistanceSquared(c1, c2 color.RGBA) float64 {
+	dr := float64(c1.R) - float64(c2.R)
+	dg := float64(c1.G) - float64(c2.G)
+	db := float64(c1.B) - float64(c2.B)
+	return dr*dr + dg*dg + db*db
+}
+
+func findNClosestColors(originalRGBA color.RGBA, paletteRGBAs []color.RGBA, n int) []struct {
+	dist  float64
+	color color.RGBA
+} {
+	// Early termination if exact match found
+	for _, pRGBA := range paletteRGBAs {
+		if originalRGBA == pRGBA {
+			return []struct {
+				dist  float64
+				color color.RGBA
+			}{{dist: 0, color: pRGBA}}
+		}
+	}
+
+	distances := make([]struct {
+		dist  float64
+		color color.RGBA
+	}, 0, len(paletteRGBAs))
+
+	for _, pRGBA := range paletteRGBAs {
+		distances = append(distances, struct {
+			dist  float64
+			color color.RGBA
+		}{dist: colorDistanceSquared(originalRGBA, pRGBA), color: pRGBA})
+	}
+
+	sort.Slice(distances, func(i, j int) bool {
+		return distances[i].dist < distances[j].dist
+	})
+
+	if n > len(distances) {
+		n = len(distances)
+	}
+	return distances[:n]
+}
+
+func blendColors(colors []color.RGBA, weights []float64) color.RGBA {
+	if len(colors) == 0 || len(colors) != len(weights) {
+		return color.RGBA{}
+	}
+
+	var sumR, sumG, sumB float64
+	var totalWeight float64
+
+	for i := range colors {
+		sumR += float64(colors[i].R) * weights[i]
+		sumG += float64(colors[i].G) * weights[i]
+		sumB += float64(colors[i].B) * weights[i]
+		totalWeight += weights[i]
+	}
+
+	if totalWeight == 0 {
+		return colors[0]
+	}
+
+	return color.RGBA{
+		R: uint8(math.Round(sumR / totalWeight)),
+		G: uint8(math.Round(sumG / totalWeight)),
+		B: uint8(math.Round(sumB / totalWeight)),
+		A: 255,
+	}
+}
+
+func extractColors(sortedColors []struct {
+	dist  float64
+	color color.RGBA
+}) []color.RGBA {
+	colors := make([]color.RGBA, len(sortedColors))
+	for i, item := range sortedColors {
+		colors[i] = item.color
+	}
+	return colors
+}


### PR DESCRIPTION
This PR introduces Shepard's inverse distance weighting method as a new color correction backend, providing smooth and high-quality color interpolation for theme conversion.

### Usage

```bash
# Use Shepard's method with default settings
gowall convert input.jpg --theme catppuccin --backend shepard

# Customize parameters
gowall convert input.jpg --theme nord --backend shepard --nearest 20 --power 3.0

# Available backends for comparison
gowall convert input.jpg --theme catppuccin --backend nn     	# Nearest neighbor
gowall convert input.jpg --theme catppuccin --backend rbf    	# RBF (default)
gowall convert input.jpg --theme catppuccin --backend shepard 	# Shepard's method
```

### Background

This PR was created following [your suggestion](https://www.reddit.com/r/unixporn/comments/1kv3eb6/comment/mu7dlnu/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button) on my Reddit post about the tint project on r/unixporn, where you mentioned it would be a great fit to add Shepard's method as a backend to gowall instead of maintaining separate tools