### PR TITLE
[patch] Add FreeBSD platform support

### DIFF
--- a/internal/backends/compression/png/setup.go
+++ b/internal/backends/compression/png/setup.go
@@ -40,6 +40,7 @@ func CheckPngquantInstalled() (string, error) {
 		"linux":   config.PngquantBinaryName,
 		"windows": config.PngquantBinaryName + ".exe",
 		"darwin":  config.PngquantBinaryName,
+		"freebsd": config.PngquantBinaryName,
 	}
 
 	destFolder := filepath.Join(config.GowallConfig.OutputFolder, "compression", "pngquant")

--- a/internal/backends/onnx/setup.go
+++ b/internal/backends/onnx/setup.go
@@ -20,6 +20,8 @@ func SharedLibraryName() string {
 	switch runtime.GOOS {
 	case "linux":
 		return fmt.Sprintf("libonnxruntime.so.%s", onnxRuntimeVersion)
+	case "freebsd":
+		return fmt.Sprintf("libonnxruntime.so")
 	case "darwin":
 		return fmt.Sprintf("libonnxruntime.%s.dylib", onnxRuntimeVersion)
 	case "windows":
@@ -156,6 +158,9 @@ func SetupOnnxRuntime() error {
 // CheckOnnxRuntimeInstalled checks if the ONNX runtime shared library is available
 func CheckOnnxRuntimeInstalled() (string, error) {
 	destFolder := config.GowallConfig.OnnxRuntimeFolderPath
+	if runtime.GOOS == "freebsd" {
+		destFolder = filepath.Join("/usr/local", "lib")
+	}
 	libName := SharedLibraryName()
 
 	if libName == "" {

--- a/internal/image/upscale.go
+++ b/internal/image/upscale.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 
 	"github.com/Achno/gowall/config"
 	imageio "github.com/Achno/gowall/internal/image_io"
@@ -21,6 +22,9 @@ type UpscaleProcessor struct {
 
 func (p *UpscaleProcessor) Process(img image.Image, theme string, format string) (image.Image, types.ImageMetadata, error) {
 	destFolder := filepath.Join(config.GowallConfig.OutputFolder, "upscaler")
+	if runtime.GOOS == "freebsd" {
+		destFolder = filepath.Join("/usr/local", "bin")
+	}
 	// setup upscaler if it has not been already
 	if _, err := os.Stat(destFolder); os.IsNotExist(err) {
 
@@ -35,6 +39,7 @@ func (p *UpscaleProcessor) Process(img image.Image, theme string, format string)
 		"windows": "realesrgan-ncnn-vulkan.exe",
 		"darwin":  "realesrgan-ncnn-vulkan",
 		"linux":   "realesrgan-ncnn-vulkan",
+		"freebsd": "realesrgan-ncnn-vulkan",
 	}
 
 	binary, err := utils.FindBinary(binaryNames, destFolder)


### PR DESCRIPTION
Hi,

I'd like to upstream the patches that used for successfully building `gowall` for FreeBSD platform. They would make the packaging process easier on FreeBSD.

I have little to no programming knowledge, but tried my best doing the patches. I'd like to know if you could think of a better way to integrate support for FreeBSD.

They will make packaging process easier on FreeBSD.

Thanks in advance.